### PR TITLE
Replace Github runner with FlyCI MacOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: flyci-macos-large-latest-m1
+    runs-on: flyci-macos-large-latest-m2
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: flyci-macos-large-latest-m2
 
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-#      - name: xcode-select
-#        run: sudo xcode-select -s /Applications/Xcode_14.2.app
+      #      - name: xcode-select
+      #        run: sudo xcode-select -s /Applications/Xcode_14.2.app
       - name: brew install
         run: brew install xcodegen
       - name: package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: flyci-macos-large-latest-m2
+    runs-on: flyci-macos-large-latest-m1
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR replaces `macos-12` runner with FlyCI M2 runner which is free to use for public repositories.